### PR TITLE
Make code executable by Python v2.6

### DIFF
--- a/labrador/output/properties.py
+++ b/labrador/output/properties.py
@@ -3,6 +3,6 @@ import StringIO
 
 def dumps(d):
     out = StringIO.StringIO()
-    stringified_d = { k:str(v) for k, v in d.iteritems() }
+    stringified_d = dict((k, str(v)) for k, v in d.iteritems())
     jprops.store_properties(out, stringified_d)
     return out.getvalue()

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 setup(
     name = "Labrador",
-    version = "0.5.0",
+    version = "0.6.0",
     packages = find_packages(),
     install_requires = [
         'pyyaml',


### PR DESCRIPTION
This is necessary because the Amazon Linux AMIs run Python 2.6, not Python 2.7.
